### PR TITLE
Maven依存更新 & コード修正 & おこポイントプレホル

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,25 +25,25 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <version>1.14.4-R0.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.9.2</version>
+            <version>2.10.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.6</version>
+            <version>1.18.8</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.5-jre</version>
+            <version>23.6.1-jre</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.akaregi.imperatrix</groupId>
     <artifactId>Imperatrix</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <name>Imperatrix</name>
     <url>https://github.com/okocraft/Imperatrix</url>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.akaregi.imperatrix</groupId>
     <artifactId>Imperatrix</artifactId>

--- a/src/main/java/com/github/akaregi/imperatrix/Imperatrix.java
+++ b/src/main/java/com/github/akaregi/imperatrix/Imperatrix.java
@@ -18,15 +18,12 @@
 
 package com.github.akaregi.imperatrix;
 
-import lombok.Getter;
-
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
-
-import me.clip.placeholderapi.expansion.PlaceholderExpansion;
-
 import com.github.akaregi.imperatrix.lib.PlayerLib;
 import com.github.akaregi.imperatrix.lib.ServerLib;
+import lombok.Getter;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 
 /**
  * Imperatrix, a PlaceholderAPI expansion.
@@ -84,22 +81,24 @@ public class Imperatrix extends PlaceholderExpansion {
     /**
      * Imperatrix で実装される PAPI プレースホルダのディスパッチ処理を行う。
      *
-     * @author akaregi
-     * @since 1.0.0-SNAPSHOT
-     *
      * @param player     プレイヤー。
      * @param identifier PAPI プレースホルダの識別子。
-     *
      * @return 与えられたプレースホルダの値。真偽値や数値であっても文字列で返される。
+     * @author akaregi
+     * @since 1.0.0-SNAPSHOT
      */
     public String onPlaceholderRequest(Player player, String identifier) {
-        
+
         if (identifier.toLowerCase().startsWith("hasitem_lorepartialmatch_")) {
             return String.valueOf(PlayerLib.hasItemLorePartialMatch(player, identifier));
         }
 
         if (identifier.toLowerCase().startsWith("hasitem_")) {
             return String.valueOf(PlayerLib.hasItem(player, identifier));
+        }
+
+        if (identifier.equalsIgnoreCase("okopoint")) {
+            return String.valueOf(PlayerLib.okopoint2(player));
         }
 
         if (identifier.equalsIgnoreCase("tps")) {

--- a/src/main/java/com/github/akaregi/imperatrix/Imperatrix.java
+++ b/src/main/java/com/github/akaregi/imperatrix/Imperatrix.java
@@ -30,12 +30,15 @@ import org.bukkit.entity.Player;
  *
  * @author OKOCRAFT
  */
+
 public class Imperatrix extends PlaceholderExpansion {
+
     /**
      * この PlaceholderAPI 拡張の作者。{@link PlaceholderExpansion#getAuthor()} の実装。
      *
      * @see PlaceholderExpansion#getAuthor()
      */
+
     @Getter(onMethod = @__({@Override}))
     private final String author = "akaregi";
 
@@ -44,6 +47,7 @@ public class Imperatrix extends PlaceholderExpansion {
      *
      * @see PlaceholderExpansion#getVersion()
      */
+
     @Getter(onMethod = @__({@Override}))
     private final String version = getClass().getPackage().getImplementationVersion();
 
@@ -52,6 +56,7 @@ public class Imperatrix extends PlaceholderExpansion {
      *
      * @see PlaceholderExpansion#getIdentifier()
      */
+
     @Getter(onMethod = @__({@Override}))
     private final String identifier = "Imperatrix";
 
@@ -60,11 +65,13 @@ public class Imperatrix extends PlaceholderExpansion {
      *
      * @see Imperatrix#serverVer
      */
+
     private Object server;
 
     /**
      * サーバーインスタンス({@link Imperatrix#server})のバージョン。
      */
+
     private String serverVer;
 
     public Imperatrix() {
@@ -87,6 +94,7 @@ public class Imperatrix extends PlaceholderExpansion {
      * @author akaregi
      * @since 1.0.0-SNAPSHOT
      */
+
     public String onPlaceholderRequest(Player player, String identifier) {
 
         if (identifier.toLowerCase().startsWith("hasitem_lorepartialmatch_")) {
@@ -98,7 +106,7 @@ public class Imperatrix extends PlaceholderExpansion {
         }
 
         if (identifier.equalsIgnoreCase("okopoint")) {
-            return String.valueOf(PlayerLib.okopoint2(player));
+            return String.valueOf(PlayerLib.getOkopoint(player));
         }
 
         if (identifier.equalsIgnoreCase("tps")) {

--- a/src/main/java/com/github/akaregi/imperatrix/Imperatrix.java
+++ b/src/main/java/com/github/akaregi/imperatrix/Imperatrix.java
@@ -105,6 +105,10 @@ public class Imperatrix extends PlaceholderExpansion {
             return String.valueOf(PlayerLib.hasItem(player, identifier));
         }
 
+        if (identifier.toLowerCase().startsWith("holditem_lorepartialmatch_")) {
+            return String.valueOf(PlayerLib.holdItemLorePartialMatch(player, identifier));
+        }
+
         if (identifier.equalsIgnoreCase("okopoint")) {
             return String.valueOf(PlayerLib.getOkopoint(player));
         }

--- a/src/main/java/com/github/akaregi/imperatrix/lib/PlayerLib.java
+++ b/src/main/java/com/github/akaregi/imperatrix/lib/PlayerLib.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
  * @author OKOCRAFT
  * @since 1.0.0-SNAPSHOT
  */
+
 public class PlayerLib {
 
     /**
@@ -28,6 +29,7 @@ public class PlayerLib {
      * @param identifier 指定する文字列
      * @return マッチするアイテムがあればtrue、なければfalse
      */
+
     public static boolean hasItemLorePartialMatch(Player player, String identifier) {
         String str = identifier.substring(25);
         System.out.println(str);
@@ -58,6 +60,7 @@ public class PlayerLib {
      * @see PlayerLib#matchLore(ItemStack, String)
      * @see PlayerLib#matchEnchants(ItemStack, String)
      */
+
     public static boolean hasItem(Player player, String identifier) {
         // expected req: hasitem_id:Id,name:Name,amount:10,lore:L|L|L,enchants:E|E|E
         // expected res: ["id:Id", "amount:10", "name:Name", "lore:L|L|L",
@@ -92,7 +95,8 @@ public class PlayerLib {
      * @param player 取得するプレイヤー
      * @return 問題なく取得できればその値、 ScoreboardManager が null なら -1, okopoint2 が null なら -2
      */
-    public static int okopoint2(Player player) {
+
+    public static int getOkopoint(Player player) {
         ScoreboardManager sm = Bukkit.getScoreboardManager();
         if (sm == null) return -1;
 
@@ -124,6 +128,7 @@ public class PlayerLib {
      * @author LazyGon
      * @since 1.0.0-SNAPSHOT
      */
+
     private static boolean matchName(ItemStack item, String name) {
         if (item.getItemMeta() == null) return false;
         return (name.equals("")) || item.getItemMeta().getDisplayName().equals(name);
@@ -138,6 +143,7 @@ public class PlayerLib {
      * @author LazyGon
      * @since 1.0.0-SNAPSHOT
      */
+
     private static boolean matchLore(ItemStack item, String lore) {
         if (Objects.isNull(lore))
             return true;
@@ -161,6 +167,7 @@ public class PlayerLib {
      * @author LazyGon
      * @since 1.0.0-SNAPSHOT
      */
+
     @SuppressWarnings("deprecation")
     private static boolean matchEnchants(ItemStack item, String enchants) {
         if (Strings.isNullOrEmpty(enchants))

--- a/src/main/java/com/github/akaregi/imperatrix/lib/PlayerLib.java
+++ b/src/main/java/com/github/akaregi/imperatrix/lib/PlayerLib.java
@@ -94,6 +94,8 @@ public class PlayerLib {
      *
      * @param player 取得するプレイヤー
      * @return 問題なく取得できればその値、 ScoreboardManager が null なら -1, okopoint2 が null なら -2
+     * @author Siroshun09
+     * @since 1.2.0-SNAPSHOT
      */
 
     public static int getOkopoint(Player player) {

--- a/src/main/java/com/github/akaregi/imperatrix/lib/PlayerLib.java
+++ b/src/main/java/com/github/akaregi/imperatrix/lib/PlayerLib.java
@@ -3,6 +3,7 @@ package com.github.akaregi.imperatrix.lib;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -87,6 +88,33 @@ public class PlayerLib {
 
             return false;
         }
+    }
+
+    /**
+     * {@code identifier}に指定した文字列を含むLoreを持つアイテムがプレイヤーのインベントリに存在するときtrue
+     *
+     * @param player     判定するプレイヤー
+     * @param identifier PAPI の識別子
+     * @return マッチするアイテムがあればtrue、なければfalse
+     */
+
+    public static boolean holdItemLorePartialMatch(Player player, String identifier) {
+        String str = identifier.substring(26);
+        ItemStack mainHandItem = player.getInventory().getItemInMainHand();
+
+        if (mainHandItem.getType().equals(Material.AIR)) return false;
+
+        ItemMeta mainHandItemMeta = mainHandItem.getItemMeta();
+
+        if (mainHandItemMeta == null || !mainHandItemMeta.hasLore()) return false;
+
+        List<String> lore = mainHandItemMeta.getLore();
+
+        if (lore == null) return false;
+
+        return lore.stream()
+                .filter(loreLine -> !Strings.isNullOrEmpty(loreLine))
+                .anyMatch(loreLine -> loreLine.matches(".*" + str + ".*"));
     }
 
     /**

--- a/src/main/java/com/github/akaregi/imperatrix/lib/PlayerLib.java
+++ b/src/main/java/com/github/akaregi/imperatrix/lib/PlayerLib.java
@@ -1,49 +1,44 @@
 package com.github.akaregi.imperatrix.lib;
 
-import java.util.Map;
-import java.util.Objects;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.stream.Collectors;
-import java.util.List;
-
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-
+import org.bukkit.Bukkit;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.ScoreboardManager;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Imperatrix で実装されるプレイヤーのプレースホルダ。
  *
- * @since 1.0.0-SNAPSHOT
  * @author OKOCRAFT
+ * @since 1.0.0-SNAPSHOT
  */
 public class PlayerLib {
 
     /**
      * {@code identifier}に指定した文字列を含むLoreを持つアイテムがプレイヤーのインベントリに存在するときtrue
-     * 
-     * @param player
-     * @param identifier
+     *
+     * @param player     アイテム検証するプレイヤー
+     * @param identifier 指定する文字列
      * @return マッチするアイテムがあればtrue、なければfalse
      */
-    public static boolean hasItemLorePartialMatch(Player player, String identifier){
+    public static boolean hasItemLorePartialMatch(Player player, String identifier) {
         String str = identifier.substring(25);
         System.out.println(str);
         return Arrays.stream(player.getInventory().getContents())
                 .filter(item -> !Objects.isNull(item))
                 .map(ItemStack::getItemMeta)
+                .filter(Objects::nonNull)
                 .filter(ItemMeta::hasLore)
                 .map(ItemMeta::getLore)
-                .filter(lore -> lore.stream()
-                        .filter(loreLine -> !Strings.isNullOrEmpty(loreLine))
-                        .filter(loreLine -> loreLine.matches(".*" + str + ".*"))
-                        .count() > 0)
-                .count() > 0;
+                .filter(Objects::nonNull).anyMatch(lore -> lore.stream()
+                        .filter(loreLine -> !Strings.isNullOrEmpty(loreLine)).anyMatch(loreLine -> loreLine.matches(".*" + str + ".*")));
     }
 
     /**
@@ -54,23 +49,20 @@ public class PlayerLib {
      * <p>
      * identifier のデリミタは ","
      *
-     * @author LazyGon
-     *
      * @param player     インベントリを参照するプレイヤー
      * @param identifier PAPI の識別子
-     *
+     * @return 要求を満たしていれば true 、さもなくば false
+     * @author LazyGon
      * @see PlayerLib#matchItem(ItemStack, String)
      * @see PlayerLib#matchName(ItemStack, String)
      * @see PlayerLib#matchLore(ItemStack, String)
      * @see PlayerLib#matchEnchants(ItemStack, String)
-     *
-     * @return 要求を満たしていれば true 、さもなくば false
-     *
      */
     public static boolean hasItem(Player player, String identifier) {
         // expected req: hasitem_id:Id,name:Name,amount:10,lore:L|L|L,enchants:E|E|E
         // expected res: ["id:Id", "amount:10", "name:Name", "lore:L|L|L",
         // "enchants:E|E|E"]
+
         final Map<String, String> params = Utilities.parseItemIdentifier(identifier);
 
         try {
@@ -82,10 +74,10 @@ public class PlayerLib {
 
             final ItemStack[] inventory = player.getInventory().getContents();
 
-            return Arrays.stream(inventory).filter(item -> Objects.nonNull(item))
+            return Arrays.stream(inventory).filter(Objects::nonNull)
                     .filter(item -> matchItem(item, reqMaterial)).filter(item -> matchName(item, reqName))
                     .filter(item -> matchLore(item, reqLores)).filter(item -> matchEnchants(item, reqEnchants))
-                    .mapToInt(item -> item.getAmount()).sum() >= reqAmount;
+                    .mapToInt(ItemStack::getAmount).sum() >= reqAmount;
 
         } catch (NumberFormatException e) {
             e.printStackTrace();
@@ -95,68 +87,79 @@ public class PlayerLib {
     }
 
     /**
-     * アイテムが指定したアイテムか判定する
+     * おこポイントを取得する
      *
-     * @author LazyGon
-     * @since 1.0.0-SNAPSHOT
+     * @param player 取得するプレイヤー
+     * @return 問題なく取得できればその値、 ScoreboardManager が null なら -1, okopoint2 が null なら -2
+     */
+    public static int okopoint2(Player player) {
+        ScoreboardManager sm = Bukkit.getScoreboardManager();
+        if (sm == null) return -1;
+
+        Objective okopointObj = sm.getMainScoreboard().getObjective("okopoint2");
+        if (okopointObj == null) return -2;
+
+        return okopointObj.getScore(player.getName()).getScore();
+    }
+
+    /**
+     * アイテムが指定したアイテムか判定する
      *
      * @param item    任意のアイテム
      * @param request アイテム
-     *
      * @return 合致すれば true, さもなくば false
+     * @author LazyGon
+     * @since 1.0.0-SNAPSHOT
      */
     private static boolean matchItem(ItemStack item, String request) {
-        return (request == "") ? true : item.getType().toString().equalsIgnoreCase(request);
+        return (request.equals("")) || item.getType().toString().equalsIgnoreCase(request);
     }
 
     /**
      * アイテムが指定した名前であるか判定する
      *
-     * @author LazyGon
-     * @since 1.0.0-SNAPSHOT
-     *
      * @param item 任意のアイテム
      * @param name 名前
-     *
      * @return 合致すれば true, さもなくば false
+     * @author LazyGon
+     * @since 1.0.0-SNAPSHOT
      */
     private static boolean matchName(ItemStack item, String name) {
-        return (name == "") ? true : item.getItemMeta().getDisplayName().equals(name);
+        if (item.getItemMeta() == null) return false;
+        return (name.equals("")) || item.getItemMeta().getDisplayName().equals(name);
     }
 
     /**
      * アイテムに指定した説明文があるか判定する
      *
-     * @author LazyGon
-     * @since 1.0.0-SNAPSHOT
-     *
      * @param item 任意のアイテム
      * @param lore 説明文
-     *
      * @return lore の指定がない、または lore がアイテムの説明文と合致すれば true、さもなくば false
+     * @author LazyGon
+     * @since 1.0.0-SNAPSHOT
      */
     private static boolean matchLore(ItemStack item, String lore) {
         if (Objects.isNull(lore))
             return true;
 
         ItemMeta itemMeta = item.getItemMeta();
+        if (itemMeta == null) return false;
         if (!itemMeta.hasLore()) return false;
 
         List<String> reqLores = new ArrayList<>(Arrays.asList(lore.split("\\|", -1)));
 
+        if (itemMeta.getLore() == null) return false;
         return itemMeta.getLore().equals(reqLores);
     }
 
     /**
      * アイテムに指定したエンチャントがされているか判定する
      *
-     * @author LazyGon
-     * @since 1.0.0-SNAPSHOT
-     *
      * @param item     任意のアイテム
      * @param enchants エンチャント
-     *
      * @return enchants の指定がない、または enchants がアイテムのエンチャントと一致すれば true, さもなくば false
+     * @author LazyGon
+     * @since 1.0.0-SNAPSHOT
      */
     @SuppressWarnings("deprecation")
     private static boolean matchEnchants(ItemStack item, String enchants) {

--- a/src/main/java/com/github/akaregi/imperatrix/lib/ServerLib.java
+++ b/src/main/java/com/github/akaregi/imperatrix/lib/ServerLib.java
@@ -21,19 +21,19 @@ package com.github.akaregi.imperatrix.lib;
 import java.util.Arrays;
 
 public class ServerLib {
+
     /**
      * サーバーから生の値ではない TPS を取得する。小数点第三位以下は削られる。
      *
+     * @param server サーバーインスタンス。net.minecraft.server を要求する。
+     * @return TPS 配列、ただし各値の最大値は 20 。例: [double, double, double]
      * @author akaregi
      * @since 1.0.0-SNAPSHOT
-     *
-     * @param server サーバーインスタンス。net.minecraft.server を要求する。
-     *
-     * @return TPS 配列、ただし各値の最大値は 20 。例: [double, double, double]
      */
+
     public static double[] getRationalTPS(Object server) throws IllegalAccessException, NoSuchFieldException {
         return Arrays.stream(getTPS(server)).map(it ->
-            Math.min(Utilities.round(it, 2), 20)
+                Math.min(Utilities.round(it, 2), 20)
         ).toArray();
     }
 
@@ -41,16 +41,14 @@ public class ServerLib {
      * サーバーインスタンスから TPS を取得する。値は 20 以上になる可能性がある。
      * 最大値 20 を望むなら {@link ServerLib#getRationalTPS(Object) } を使う。
      *
-     * @author akaregi
-     * @since 1.0.0-SNAPSHOT
-     *
-     * @see ServerLib#getRationalTPS(Object)
-     *
      * @param server サーバーインスタンス。net.minecraft.server を要求する。
-     *
      * @return TPS 配列。例: [double, double, double]
+     * @author akaregi
+     * @see ServerLib#getRationalTPS(Object)
+     * @since 1.0.0-SNAPSHOT
      */
-    public static double[] getTPS(Object server) throws IllegalAccessException, NoSuchFieldException {
+
+    private static double[] getTPS(Object server) throws IllegalAccessException, NoSuchFieldException {
         return (double[]) server.getClass().getField("recentTps").get(server);
     }
 }

--- a/src/main/java/com/github/akaregi/imperatrix/lib/ServerLib.java
+++ b/src/main/java/com/github/akaregi/imperatrix/lib/ServerLib.java
@@ -33,7 +33,7 @@ public class ServerLib {
 
     public static double[] getRationalTPS(Object server) throws IllegalAccessException, NoSuchFieldException {
         return Arrays.stream(getTPS(server)).map(it ->
-                Math.min(Utilities.round(it, 2), 20)
+                Math.min(Utilities.round(it), 20)
         ).toArray();
     }
 

--- a/src/main/java/com/github/akaregi/imperatrix/lib/Utilities.java
+++ b/src/main/java/com/github/akaregi/imperatrix/lib/Utilities.java
@@ -17,23 +17,22 @@
 
 package com.github.akaregi.imperatrix.lib;
 
+import com.google.common.base.Splitter;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.google.common.base.Splitter;
 
 class Utilities {
 
     /**
      * 数値を丸める。
      *
-     * @author akaregi
-     * @since 1.0.0-SNAPSHOT
-     *
      * @param value もとの値。
      * @return 小数の位を削られた数値。
+     * @author akaregi
+     * @since 1.0.0-SNAPSHOT
      */
 
     static double round(double value) {
@@ -46,12 +45,10 @@ class Utilities {
      * <p><code>prefix_id:Id,name:Name,amount:10,lore:L|L|L,enchants:E|E|E</code> を
      * <code> { id: "Id", name: "Name", amount: 10, lore: "L|L|L", enchants: E|E|E" }</code> にする。
      *
+     * @param identifier NBT 表現。
+     * @return 連想配列に変換された NBT 表現。
      * @author LazyGon
      * @since 1.0.0-SNAPSHOT
-     *
-     * @param identifier NBT 表現。
-     *
-     * @return 連想配列に変換された NBT 表現。
      */
 
     static Map<String, String> parseItemIdentifier(String identifier) {

--- a/src/main/java/com/github/akaregi/imperatrix/lib/Utilities.java
+++ b/src/main/java/com/github/akaregi/imperatrix/lib/Utilities.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import com.google.common.base.Splitter;
 
 class Utilities {
+
     /**
      * 数値を丸める。
      *
@@ -36,6 +37,7 @@ class Utilities {
      *
      * @return 小数の位を削られた数値。
      */
+
     public static double round(double value, Integer place) {
         return BigDecimal.valueOf(value).setScale(place, RoundingMode.HALF_UP).doubleValue();
     }
@@ -53,6 +55,7 @@ class Utilities {
      *
      * @return 連想配列に変換された NBT 表現。
      */
+
     public static Map<String, String> parseItemIdentifier(String identifier) {
         Map<String, String> params = new HashMap<String, String>();
 

--- a/src/main/java/com/github/akaregi/imperatrix/lib/Utilities.java
+++ b/src/main/java/com/github/akaregi/imperatrix/lib/Utilities.java
@@ -33,13 +33,11 @@ class Utilities {
      * @since 1.0.0-SNAPSHOT
      *
      * @param value もとの値。
-     * @param place 残す小数の位。2 なら 20.00 のようになる。
-     *
      * @return 小数の位を削られた数値。
      */
 
-    public static double round(double value, Integer place) {
-        return BigDecimal.valueOf(value).setScale(place, RoundingMode.HALF_UP).doubleValue();
+    static double round(double value) {
+        return BigDecimal.valueOf(value).setScale(2, RoundingMode.HALF_UP).doubleValue();
     }
 
     /**
@@ -56,8 +54,8 @@ class Utilities {
      * @return 連想配列に変換された NBT 表現。
      */
 
-    public static Map<String, String> parseItemIdentifier(String identifier) {
-        Map<String, String> params = new HashMap<String, String>();
+    static Map<String, String> parseItemIdentifier(String identifier) {
+        Map<String, String> params = new HashMap<>();
 
         try {
             params = Splitter.on(",").trimResults().withKeyValueSeparator(":")


### PR DESCRIPTION
## Maven 依存
- Spigot 1.13.2 → 1.14.4 
- PAPI 2.9.2 → 2.10.2 (.3 が最新だがなかった)
- lombok 1.18.6 → 1.18.8
- guava 23.5-jre → 23.6.1-jre

## コード修正
- import 整理 & 最適化
- Javadoc 不足分追加
- IntellIJ による整形
- ラムダで記述
- NPE 対策

※ hasItemはラムダになっただけなのでおそらく大丈夫ですが、hasItemLorePartialMatch はかなり変わっているので検証必要。

 ## おこポイントプレホル
おこポイントの値を取るだけの専用プレホルを作成 `%Imperatrix_okopoint%

NPE 出るぞー! うるさいので

- 正常に取得できたらその値
- ScoreboardManager が null なら -1
- okopoint2 が null なら -2

を返すようにしています